### PR TITLE
Add currentSlide property to dotProps

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -679,7 +679,8 @@ export class InnerSlider extends React.Component {
         clickHandler: this.changeSlide,
         onMouseEnter: pauseOnDotsHover ? this.onDotsLeave : null,
         onMouseOver: pauseOnDotsHover ? this.onDotsOver : null,
-        onMouseLeave: pauseOnDotsHover ? this.onDotsLeave : null
+        onMouseLeave: pauseOnDotsHover ? this.onDotsLeave : null,
+        currentSlide: Math.round(dotProps.currentSlide)
       };
       dots = <Dots {...dotProps} />;
     }


### PR DESCRIPTION
The currentSlide property, calculated as the rounded value of dotProps.currentSlide, has been added to dotProps in inner-slider.js. This modification enhances dot navigation within the slide, improving user experience.