### PR TITLE
Update package version and repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-slick-fixed-dots",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "description": " React port of slick carousel",
   "main": "./lib",
   "files": [


### PR DESCRIPTION
Updated the version of the "react-slick-fixed-dots" package from 0.30.3 to 0.30.4. Additionally, the repository URL was changed to reflect the new authority of the package under the "jimbokid" handle. These updates ensure the package's meta-data is consistent with its current status.